### PR TITLE
Correct Geospatial links after Db2 Warehouse Knowledge Center split

### DIFF
--- a/sqlref/geospatial.md
+++ b/sqlref/geospatial.md
@@ -2,7 +2,7 @@
 
 copyright:
   year: 2018, 2019
-lastupdated: "2019-04-04"
+lastupdated: "2019-07-18"
 
 keywords: geospatial, function, spatial data
 
@@ -22,6 +22,6 @@ subcollection: sql-query
 # Geospatial functions
 {: #geo-functions}
 
-The [Geospatial Toolkit](https://www.ibm.com/support/knowledgecenter/SS6NHC/com.ibm.swg.im.dashdb.analytics.doc/doc/geo_intro.html) provides a set 
-of [geospatial functions](https://www.ibm.com/support/knowledgecenter/SS6NHC/com.ibm.swg.im.dashdb.analytics.doc/doc/geo_functions.html) 
+The [Geospatial Toolkit](https://www.ibm.com/support/knowledgecenter/en/SSCJDQ/com.ibm.swg.im.dashdb.analytics.doc/doc/geo_intro.html) provides a set 
+of [geospatial functions](https://www.ibm.com/support/knowledgecenter/en/SSCJDQ/com.ibm.swg.im.dashdb.analytics.doc/doc/geo_functions.html) 
 that you can use to efficiently process and index spatial data.


### PR DESCRIPTION
The Db2 Warehouse Knowledge Center has been split into a few different ones, one for each flavor (Db2 Warehouse, Db2 Warehouse on Cloud, IIAS). Thus the old links do not work anymore.