### PR TITLE
Typo fix sql reference

### DIFF
--- a/sqlref/sql_reference.md
+++ b/sqlref/sql_reference.md
@@ -3221,7 +3221,7 @@ ALTER TABLE customers_partitioned RECOVER PARTITIONS
 
 In order to add or remove partitions individually, use the `ADD PARTITION` or `DROP PARTITION` options.
 
-The `ADD PARTITON` option allows you to specify an explicit location for the new partition. This way, you can construct a table from object locations that do not share a common {{site.data.keyword.cos_short}} prefix, or are even located in separate buckets. If the partiton location is not specified, it is inferred from the location of the table and the value(s) of the partitioning column(s). `ADD PARTITION` does not validate the specified or inferred location.
+The `ADD PARTITION` option allows you to specify an explicit location for the new partition. This way, you can construct a table from object locations that do not share a common {{site.data.keyword.cos_short}} prefix, or are even located in separate buckets. If the partition location is not specified, it is inferred from the location of the table and the value(s) of the partitioning column(s). `ADD PARTITION` does not validate the specified or inferred location.
 
 
 ```sql


### PR DESCRIPTION
Issue #11 TYPO

#description
hey, There was a typo at the site: https://cloud.ibm.com/docs/sql-query?topic=sql-query-sql-reference#partitionSpec
which I fixed, Sorry if I broke any protocol with this PR.
Do let me know if there should be any changes to my PR.


# changes
add partition -> add partition 
in
The ADD PARTITON option allows you to specify an explicit location for the new partition.

